### PR TITLE
ignore ramfs

### DIFF
--- a/src/mountpoints.rs
+++ b/src/mountpoints.rs
@@ -10,8 +10,9 @@ pub struct MountPoint {
 
 impl MountPoint {
     pub fn collect_from_file(path: &str) -> Vec<MountPoint> {
-        const FSTYPE_IGNORE: [&str; 8] = [
+        const FSTYPE_IGNORE: [&str; 9] = [
             "tmpfs",
+            "ramfs",
             "swap",
             "devtmpfs",
             "devpts",


### PR DESCRIPTION
`tmpfs` is already being ignored, thus it makes sense to ignore `ramfs` too. Ramfs is basically the same as tmpfs, but without the ability to use swap.