### PR TITLE
Add config file option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,12 +686,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -812,7 +818,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -872,10 +878,13 @@ version = "0.1.1"
 dependencies = [
  "crossterm",
  "ratatui",
+ "serde",
  "sys-mount",
  "tokio",
  "tokio-stream",
+ "toml",
  "udisks2",
+ "xdg",
 ]
 
 [[package]]
@@ -1208,18 +1217,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1235,6 +1254,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1459,10 +1487,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.10+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1471,9 +1523,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.8",
+ "winnow 0.6.20",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tracing"
@@ -1695,6 +1762,18 @@ checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "xdg-home"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,13 @@ license = "MIT"
 [dependencies]
 crossterm = { version = "0.28.1", features = ["event-stream"]}
 ratatui = "0.29.0"
+serde = "1.0.228"
 sys-mount = "3.0.1"
 tokio = {version = "1.42.0", features = ["full"]}
 tokio-stream = "0.1.17"
+toml = "0.9.10"
 udisks2 = "0.2.0"
+xdg = "3.0.0"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,46 @@ Binary will be in `target/release/mmtui`
 
 On Archlinux you can install from AUR, package is named `mmtui-bin`: https://aur.archlinux.org/packages/mmtui-bin
 
+## Configuration
+
+mmtui supports an optional configuration file located at:
+
+`$XDG_CONFIG_HOME/mmtui/mmtui.toml`
+
+Given a relative path, mmtui searches `XDG_CONFIG_HOME` first and then `XDG_CONFIG_DIRS`, using the first existing configuration file found. If no configuration file found, built-in defaults are used. If a configuration file exists, it fully overrides the default configuration. The lookup is based on [freedesktop.org XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/).
+
+The following shows the built-in default configuration used when no configuration file is present:
+```toml
+fstype_ignore = [
+        "tmpfs",
+        "ramfs",
+        "swap",
+        "devtmpfs",
+        "devpts",
+        "hugetlbfs",
+        "mqueue",
+        "fuse.portal",
+        "fuse.gvfsd-fuse",
+
+]
+path_ignore =  [
+        "/tmp",
+        "/sys",
+        "/proc",
+]
+```
+
+### Options
+
+All options must be present in the configuration file. Options cannot be omitted; use an empty list if no entries are desired.
+
+* `fstype_ignore`
+    List of filesystem types to ignore. Any mount whose filesystem type matches an entry in this list will be excluded.
+
+* `path_ignore`
+    List of absolute paths to ignore. Any mount point or path matching an entry in this list will be excluded.
+
+
 # Integrations
 
 ## Yazi - mount.yazi

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,62 @@
+use serde::Deserialize;
+use std::fs;
+use std::vec::Vec;
+use xdg::BaseDirectories;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub fstype_ignore: Vec<String>,
+    pub path_ignore: Vec<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            fstype_ignore: [
+                "tmpfs",
+                "ramfs",
+                "swap",
+                "devtmpfs",
+                "devpts",
+                "hugetlbfs",
+                "mqueue",
+                "fuse.portal",
+                "fuse.gvfsd-fuse",
+            ]
+            .map(String::from)
+            .to_vec(),
+            path_ignore: ["/tmp", "/sys", "/proc"].map(String::from).to_vec(),
+        }
+    }
+}
+
+impl Config {
+    pub fn load_or_default() -> Self {
+        Self::load().unwrap_or_default()
+    }
+
+    fn load() -> Option<Self> {
+        let basedirs = BaseDirectories::with_prefix("mmtui");
+        let path = basedirs.find_config_file("mmtui.toml")?;
+
+        println!("Load config file from: {}", path.display());
+
+        let data = match fs::read_to_string(&path) {
+            Ok(data) => data,
+            Err(err) => {
+                eprintln!("Failed to read config file using default config:");
+                eprintln!("{err}");
+                return None;
+            }
+        };
+
+        match toml::from_str(&data) {
+            Ok(config) => Some(config),
+            Err(err) => {
+                eprintln!("Failed to parse config file using default config:");
+                eprintln!("{err}");
+                None
+            }
+        }
+    }
+}

--- a/src/drives.rs
+++ b/src/drives.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::mountpoints;
 use std::collections::HashMap;
 
@@ -94,9 +95,9 @@ pub async fn collect_drives_from_udisk() -> udisks2::Result<Vec<Drive>> {
     Ok(drives)
 }
 
-pub async fn collect_all() -> udisks2::Result<Vec<Drive>> {
+pub async fn collect_all(config: &Config) -> udisks2::Result<Vec<Drive>> {
     let mut drives = collect_drives_from_udisk().await?;
-    let mounts = mountpoints::MountPoint::collect();
+    let mounts = mountpoints::MountPoint::collect(config);
 
     let mut fstab = Drive {
         id: "fstab".to_owned(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
+mod config;
 mod drives;
 mod mountpoints;
 mod tui;
 
+use crate::config::Config;
 use crossterm::{
     event::{Event, EventStream, KeyEventKind},
     execute,
@@ -15,6 +17,7 @@ use tui::{InputResult, Tui};
 
 #[tokio::main]
 async fn main() -> udisks2::Result<()> {
+    let config = Config::load_or_default();
     enable_raw_mode().unwrap();
     execute!(stderr(), EnterAlternateScreen).unwrap();
     let mut terminal = Terminal::new(CrosstermBackend::new(stderr())).unwrap();
@@ -27,7 +30,7 @@ async fn main() -> udisks2::Result<()> {
     let s = state.clone();
     tokio::spawn(async move {
         loop {
-            if let Ok(drv) = drives::collect_all().await {
+            if let Ok(drv) = drives::collect_all(&config).await {
                 s.lock().await.clone_from(&drv);
             };
             tokio::time::sleep(Duration::from_millis(500)).await;


### PR DESCRIPTION
The configuration file is looked up with xdg crate: https://specifications.freedesktop.org/basedir/latest/

The configuration file is toml and the following fileds are supported:

*fstype_ignore*: list of filesystem type to ignore, overrides the
                 default built in list (see below)

*path_ignore*: list of path that should be ignored, overrides the
               default built in list (see below)

The default configuration is used if no configuration file is found:
```toml
fstype_ignore = [
        "tmpfs",
        "ramfs",
        "swap",
        "devtmpfs",
        "devpts",
        "hugetlbfs",
        "mqueue",
        "fuse.portal",
        "fuse.gvfsd-fuse",

]
path_ignore =  [
        "/tmp",
        "/sys",
        "/proc"
]
```

Resolve #3 